### PR TITLE
"Getting Target Temperature" shows wrong value

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Complies with ```Service.Thermostat``` with an additional Characteristic.On
 ## Installation
 
 1. Install homebridge using: `npm install -g homebridge`
-2. Install this plugin using: `npm install -g homebridge-tadoHeating`  (NPM TO BE SET UP - USE THIS GIT IN MEANTIME)
+2. Install this plugin using: `npm install -g homebridge-tadoheating` 
 3. Create/update your configuration file. See `sample-config.json` in this repository for a sample.
 4. MAKE SURE your config.json is placed in ~/.homebridge (took me ages to work this out :( )
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ This is a fork from original ckuburlis/homebridge-tado which is for AirCon - thi
 This fork has also been improved to add the ability to turn the heating on and off.
 
 For reference supports the following commands with Siri:
-"Whats the room temperature", answers "The current temperature is at 21ºc" after obtaining temperature from tado
-"Set the temperature to 22º", answers "Ok X, I've set the Tado to about 22ºC" after setting a manual override temperature on tado to 22º*
-"Turn off the heating", answers "Ok, the Tado is off" after setting a manual override to turn off the heating.
-"Turn on the heating", answer "Ok, the Tado is on" after removing the manual overrides so heating will turn on. This basically reverts the tado back to its normal automatic mode.
+* "Whats the room temperature", answers "The current temperature is at 21ºc" after obtaining temperature from tado
+* "Set the temperature to 22º", answers "Ok X, I've set the Tado to about 22ºC" after setting a manual override temperature on tado to 22º
+* "Turn off the heating", answers "Ok, the Tado is off" after setting a manual override to turn off the heating.
+* "Turn on the heating", answer "Ok, the Tado is on" after removing any manual overrides so heating will turn on. This will also always revert the tado back to its normal automatic mode.
 
-* All overrides are set with the "Until next mode change" option, so the tado settings will revert back to their normal settings.
+\* All manual overrides are set with the "Until next mode change" option, so the tado settings will revert back to their normal automatic settings on a mode change (get up/leaving home/going to bed).
 
-Complies with ```Service.Thermostat```
+Complies with ```Service.Thermostat``` with an additional Characteristic.On
 
 ## Installation
 
 1. Install homebridge using: `npm install -g homebridge`
-2. Install this plugin using: `npm install -g homebridge-tado`
-3. Update your configuration file. See `sample-config.json` in this repository for a sample.
-MAKE SURE config.json is placed in ~/.homebridge (took me ages to work this out :( )
+2. Install this plugin using: `npm install -g homebridge-tadoHeating`  (NPM TO BE SET UP - USE THIS GIT IN MEANTIME)
+3. Create/update your configuration file. See `sample-config.json` in this repository for a sample.
+4. MAKE SURE your config.json is placed in ~/.homebridge (took me ages to work this out :( )
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
-homebridge-tado FOR HEATING
-===========================
+homebridge-tadoHeating
+======================
 
-Supports triggering Tado Smart HEATING from the HomeBridge platform.
+Supports triggering Tado Smart Heating from the HomeBridge platform.
 
 This is a fork from original ckuburlis/homebridge-tado which is for AirCon - this fork is adapted for Tado Heating
+
+This fork has also been improved to add the ability to turn the heating on and off.
+
+For reference supports the following commands with Siri:
+"Whats the room temperature", answers "The current temperature is at 21ºc" after obtaining temperature from tado
+"Set the temperature to 22º", answers "Ok X, I've set the Tado to about 22ºC" after setting a manual override temperature on tado to 22º*
+"Turn off the heating", answers "Ok, the Tado is off" after setting a manual override to turn off the heating.
+"Turn on the heating", answer "Ok, the Tado is on" after removing the manual overrides so heating will turn on. This basically reverts the tado back to its normal automatic mode.
+
+* All overrides are set with the "Until next mode change" option, so the tado settings will revert back to their normal settings.
 
 Complies with ```Service.Thermostat```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-homebridge-tado
-==============
+homebridge-tado FOR HEATING
+===========================
 
-Supports triggering Tado Smart AC from the HomeBridge platform.
+Supports triggering Tado Smart HEATING from the HomeBridge platform.
+
+This is a fork from original ckuburlis/homebridge-tado which is for AirCon - this fork is adapted for Tado Heating
 
 Complies with ```Service.Thermostat```
 
@@ -10,6 +12,7 @@ Complies with ```Service.Thermostat```
 1. Install homebridge using: `npm install -g homebridge`
 2. Install this plugin using: `npm install -g homebridge-tado`
 3. Update your configuration file. See `sample-config.json` in this repository for a sample.
+MAKE SURE config.json is placed in ~/.homebridge (took me ages to work this out :( )
 
 ## Configuration
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,11 @@ TadoAccessory.prototype.getServices = function() {
     thermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)
         .on('set', this.setTargetHeatingCoolingState.bind(this));
 
+    thermostatService.addCharacteristic(Characteristic.On);
+
+    thermostatService.getCharacteristic(Characteristic.On)
+       .on('set', this.setTargetHeatingCoolingState.bind(this));
+
     // if (this.stateCommand) {
     thermostatService.getCharacteristic(Characteristic.CurrentTemperature)
         .setProps({
@@ -144,7 +149,7 @@ TadoAccessory.prototype.getCurrentTemperature = function(callback) {
         //the whole response has been recieved, so we just print it out here
         response.on('end', function() {
             var obj = JSON.parse(str);
-            accessory.log("Room temperature is " + obj.sensorDataPoints.insideTemperature.celsius + "ºC");
+            accessory.log("Room temperature is " + obj.sensorDataPoints.insideTemperature.celsius + "ºc");
             callback(null, obj.sensorDataPoints.insideTemperature.celsius);
         });
     };
@@ -256,8 +261,21 @@ TadoAccessory.prototype.setTargetHeatingCoolingState = function(state, callback)
 
         https.request(options, null).end(body);
     } else {
+        //This will reset back to automatic Tado mode and remove
+        //all overlays (aka manual overrides)
         accessory.log("Turn on");
-        this.setTargetTemperature(this.temp, callback);
+        // this.setTargetTemperature(this.temp, callback);
+        body = {};
+        body = JSON.stringify(body);
+        var options = {
+            host: 'my.tado.com',
+            path: '/api/v2/homes/' + accessory.homeID + '/zones/1/overlay?username=' + accessory.username + '&password=' + accessory.password,
+            method: 'DELETE'
+        };
+
+        callback(null);
+
+        https.request(options, null).end(body);
     }
 
 }

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ TadoAccessory.prototype.getCurrentTemperature = function(callback) {
         //the whole response has been recieved, so we just print it out here
         response.on('end', function() {
             var obj = JSON.parse(str);
-            accessory.log("Room temperature is " + obj.sensorDataPoints.insideTemperature.celsius + "Âºc");
+            accessory.log("Room temperature is " + obj.sensorDataPoints.insideTemperature.celsius + "ºC");
             callback(null, obj.sensorDataPoints.insideTemperature.celsius);
         });
     };
@@ -154,7 +154,7 @@ TadoAccessory.prototype.getCurrentTemperature = function(callback) {
 
 TadoAccessory.prototype.getTargetTemperature = function(callback) {
     var accessory = this;
-    accessory.log("Target temperature is " + this.temp + "ÂºC");
+    accessory.log("Target temperature is " + this.temp + "ºC");
 
     callback(null, this.temp);
 }
@@ -264,7 +264,7 @@ TadoAccessory.prototype.setTargetHeatingCoolingState = function(state, callback)
 
 TadoAccessory.prototype.setTargetTemperature = function(temp, callback) {
     var accessory = this;
-    accessory.log("Setting temperature to " + temp + "Âº");
+    accessory.log("Setting temperature to " + temp + "º");
 
     this.temp = temp;
 

--- a/package.json
+++ b/package.json
@@ -1,29 +1,21 @@
 {
-  "name": "homebridge-tado",
+  "name": "homebridge-tadoheating",
   "version": "0.1.0",
-  "description": "Tado plugin for homebridge: https://github.com/nfarina/homebridge",
-  "license": "MIT",
-  "keywords": [
-    "homebridge-plugin"
-  ],
-  "engines": {
-    "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
-  },
-  "author": "Chris Kuburlis",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/ckuburlis/homebridge-tado.git"
-  },
-  "dependencies": {
-    "object-assign": "^4.0.1"
-  },
-  "bugs": {
-    "url": "https://github.com/ckuburlis/homebridge-tado/issues"
-  },
-  "homepage": "https://github.com/ckuburlis/homebridge-tado#readme",
+  "description": "homebridge-tado ==============",
   "main": "index.js",
+  "dependencies": {},
+  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/peteakalad/homebridge-tadoHeating.git"
+  },
+  "author": "Peter Stevenson <peterstevenson@ihut.co.uk> (https://github.com/peteakalad/homebridge-tadoHeating)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/peteakalad/homebridge-tadoHeating/issues"
+  },
+  "homepage": "https://github.com/peteakalad/homebridge-tadoHeating#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-tadoheating",
   "version": "0.1.0",
-  "description": "homebridge-tado ==============",
+  "description": "homebridge-tadoheating"
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-tadoheating",
   "version": "0.1.0",
-  "description": "homebridge-tadoheating"
+  "description": "homebridge-tadoheating",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "homebridge-tadoheating",
   "main": "index.js",
-  "dependencies": {},
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -19,8 +18,13 @@
   },
   "homepage": "https://github.com/peteakalad/homebridge-tadoHeating#readme",
   "keywords": [
-    "homebridge",
-    "tado",
-    "heating"
-  ]
+    "homebridge-plugin"
+  ],
+  "engines": {
+    "node": ">=0.12.0",
+    "homebridge": ">=0.2.0"
+  },
+  "dependencies": {
+    "object-assign": "^4.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git+https://github.com/peteakalad/homebridge-tadoHeating.git"
   },
-  "author": "Peter Stevenson <peterstevenson@ihut.co.uk> (https://github.com/peteakalad/homebridge-tadoHeating)",
+  "author": "Peter Stevenson <pete@ihut.co.uk> (https://github.com/peteakalad/homebridge-tadoHeating)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/peteakalad/homebridge-tadoHeating/issues"

--- a/package.json
+++ b/package.json
@@ -17,5 +17,10 @@
   "bugs": {
     "url": "https://github.com/peteakalad/homebridge-tadoHeating/issues"
   },
-  "homepage": "https://github.com/peteakalad/homebridge-tadoHeating#readme"
+  "homepage": "https://github.com/peteakalad/homebridge-tadoHeating#readme",
+  "keywords": [
+    "homebridge",
+    "tado",
+    "heating"
+  ]
 }


### PR DESCRIPTION
Hello! In my configuration, the target temperature is not read correctly from TADO API, my log shows this:
[11/2/2016, 12:24:18 AM] [Tado] Getting current state
[11/2/2016, 12:24:18 AM] [Tado] Getting room temperature
[11/2/2016, 12:24:18 AM] [Tado] Target temperature is 21ºC
[11/2/2016, 12:24:18 AM] [Tado] getting temperature display units = 0
[11/2/2016, 12:24:18 AM] [Tado] Getting target state
[11/2/2016, 12:24:18 AM] [Tado] Current state is ON
[11/2/2016, 12:24:18 AM] [Tado] Target state is ON
[11/2/2016, 12:24:18 AM] [Tado] Room temperature is 20.03ºc

But the current target temperature this time is 18°C!

Can someone help?

ThX!!
